### PR TITLE
feat(ui): WOW overhaul – sticky glass navbar, gradient hero, polished cards, admin KPIs, dark-mode everywhere

### DIFF
--- a/scripts/smoke.ts
+++ b/scripts/smoke.ts
@@ -2,6 +2,7 @@ import { spawn } from "node:child_process";
 
 const routes = ["/", "/el", "/el/login", "/el/announcements", "/el/articles", "/el/events"];
 const base = "http://localhost:4000";
+const classChecks = ["sticky top-0", "backdrop-blur"];
 
 function wait(ms: number) { return new Promise(r => setTimeout(r, ms)); }
 
@@ -53,6 +54,15 @@ async function run() {
     }
   }
 
+  if (allGood) {
+    const res = await fetch(base + "/el");
+    const html = await res.text();
+    for (const c of classChecks) {
+      const pass = html.includes(c);
+      console.log(`class:${c} -> ${pass ? "✓" : "✗"}`);
+      if (!pass) allGood = false;
+    }
+  }
   killServer();
   if (!allGood) process.exit(1);
 }

--- a/src/app/[locale]/admin/AdminNav.tsx
+++ b/src/app/[locale]/admin/AdminNav.tsx
@@ -1,0 +1,35 @@
+'use client'
+import Link from 'next/link'
+import { usePathname } from 'next/navigation'
+import clsx from 'clsx'
+
+export default function AdminNav({ locale }: { locale: string }) {
+  const pathname = usePathname()
+  const base = `/${locale}/admin`
+  const tabs = [
+    { href: base, label: 'Overview' },
+    { href: `${base}/articles`, label: 'Articles' },
+    { href: `${base}/announcements`, label: 'Announcements' },
+    { href: `${base}/events`, label: 'Events' },
+    { href: `${base}/applications`, label: 'Applications' },
+    { href: `${base}/email`, label: 'Email' },
+    { href: `${base}/zoom`, label: 'Zoom' },
+    { href: `${base}/admins`, label: 'Admins' },
+  ]
+  return (
+    <nav className="flex gap-4 text-sm">
+      {tabs.map(t => (
+        <Link
+          key={t.href}
+          href={t.href}
+          className={clsx(
+            'px-2 py-1 rounded-md hover:text-foreground',
+            pathname === t.href ? 'text-primary underline underline-offset-4' : 'text-muted-foreground'
+          )}
+        >
+          {t.label}
+        </Link>
+      ))}
+    </nav>
+  )
+}

--- a/src/app/[locale]/admin/admins/page.tsx
+++ b/src/app/[locale]/admin/admins/page.tsx
@@ -1,4 +1,8 @@
 import { supabaseServer } from '@/lib/supabaseServer'
+import { Card, CardContent } from '@/components/ui/card'
+import Input from '@/components/ui/input'
+import Select from '@/components/ui/select'
+import Button from '@/components/ui/button'
 
 export const dynamic = 'force-dynamic'
 
@@ -23,21 +27,25 @@ export default async function AdminAdmins() {
   return (
     <div className="container py-8 space-y-4">
       <h1 className="text-xl font-semibold">Admins</h1>
-      <ul className="list-disc pl-5">
-        {admins?.map((a: any) => <li key={a.user_id}>{a.user_id} – {a.role}</li>)}
-      </ul>
-      <form action={add} className="flex gap-2">
-        <input name="user_id" placeholder="User ID" className="input" />
-        <select name="role" className="input">
-          <option value="admin">admin</option>
-          <option value="super_admin">super_admin</option>
-        </select>
-        <button className="btn">Add</button>
-      </form>
-      <form action={remove} className="flex gap-2">
-        <input name="user_id" placeholder="User ID" className="input" />
-        <button className="btn">Remove</button>
-      </form>
+      <Card>
+        <CardContent className="p-4 space-y-4">
+          <ul className="list-disc pl-5 space-y-1">
+            {admins?.map((a: any) => <li key={a.user_id}>{a.user_id} – {a.role}</li>)}
+          </ul>
+          <form action={add} className="flex flex-wrap gap-2">
+            <Input name="user_id" placeholder="User ID" className="w-full md:w-auto" />
+            <Select name="role" className="w-full md:w-auto">
+              <option value="admin">admin</option>
+              <option value="super_admin">super_admin</option>
+            </Select>
+            <Button>Add</Button>
+          </form>
+          <form action={remove} className="flex flex-wrap gap-2">
+            <Input name="user_id" placeholder="User ID" className="w-full md:w-auto" />
+            <Button>Remove</Button>
+          </form>
+        </CardContent>
+      </Card>
     </div>
   )
 }

--- a/src/app/[locale]/admin/announcements/page.tsx
+++ b/src/app/[locale]/admin/announcements/page.tsx
@@ -3,26 +3,45 @@ export const runtime = "nodejs";
 export const dynamic = "force-dynamic";
 import Link from "next/link";
 import { listAnnouncements } from "@/data/admin/announcements";
+import { Card, CardHeader, CardContent } from '@/components/ui/card'
+import Button from '@/components/ui/button'
 
 export default async function Page({ params }: { params: { locale: string } }) {
   const rows = await listAnnouncements();
   return (
-    <div className="space-y-4">
-      <div className="flex items-center justify-between">
+    <Card>
+      <CardHeader className="flex items-center justify-between">
         <h2 className="text-xl font-medium">Announcements</h2>
-        <Link className="btn" href={`/${params.locale}/admin/announcements/new`}>New</Link>
-      </div>
-      <ul className="divide-y">
-        {rows.map((r: any) => (
-          <li key={r.id} className="py-3 flex items-center justify-between">
-            <div>
-              <div className="font-semibold">{r.title}</div>
-              <div className="text-xs text-gray-500">{r.slug} • {r.lang}</div>
-            </div>
-            <Link className="text-sm underline" href={`/${params.locale}/admin/announcements/${r.slug}`}>Edit</Link>
-          </li>
-        ))}
-      </ul>
-    </div>
+        <Link href={`/${params.locale}/admin/announcements/new`}>
+          <Button size="sm">New</Button>
+        </Link>
+      </CardHeader>
+      <CardContent className="p-0">
+        <table className="w-full text-sm">
+          <thead className="bg-muted/40 text-left">
+            <tr>
+              <th className="p-2">Title</th>
+              <th className="p-2">Slug</th>
+              <th className="p-2">Lang</th>
+              <th className="p-2"></th>
+            </tr>
+          </thead>
+          <tbody>
+            {rows.map((r: any, idx: number) => (
+              <tr key={r.id} className={idx % 2 ? 'odd:bg-muted/10' : ''}>
+                <td className="p-2 font-medium">{r.title}</td>
+                <td className="p-2 text-muted-foreground">{r.slug}</td>
+                <td className="p-2 text-muted-foreground">{r.lang}</td>
+                <td className="p-2 text-right">
+                  <Link className="underline" href={`/${params.locale}/admin/announcements/${r.slug}`}>
+                    Edit
+                  </Link>
+                </td>
+              </tr>
+            ))}
+          </tbody>
+        </table>
+      </CardContent>
+    </Card>
   );
 }

--- a/src/app/[locale]/admin/applications/page.tsx
+++ b/src/app/[locale]/admin/applications/page.tsx
@@ -1,4 +1,6 @@
 import { supabaseServer } from '@/lib/supabaseServer'
+import { Card, CardContent } from '@/components/ui/card'
+import Button from '@/components/ui/button'
 
 export const dynamic = 'force-dynamic'
 
@@ -34,14 +36,18 @@ export default async function AdminApplications() {
       <h1 className="text-xl font-semibold">Applications</h1>
       <ul className="space-y-4">
         {apps?.map((a: any) => (
-          <li key={a.id} className="border p-4 rounded">
-            <p className="font-medium">{a.full_name}</p>
-            <p className="text-sm">{a.email}</p>
-            <form action={process} className="mt-2 flex gap-2">
-              <input type="hidden" name="id" value={a.id} />
-              <button name="action" value="approve" className="btn">Approve</button>
-              <button name="action" value="reject" className="btn" formNoValidate>Reject</button>
-            </form>
+          <li key={a.id}>
+            <Card>
+              <CardContent className="p-4">
+                <p className="font-medium">{a.full_name}</p>
+                <p className="text-sm text-muted-foreground">{a.email}</p>
+                <form action={process} className="mt-2 flex gap-2">
+                  <input type="hidden" name="id" value={a.id} />
+                  <Button name="action" value="approve">Approve</Button>
+                  <Button name="action" value="reject" formNoValidate variant="secondary">Reject</Button>
+                </form>
+              </CardContent>
+            </Card>
           </li>
         ))}
       </ul>

--- a/src/app/[locale]/admin/articles/page.tsx
+++ b/src/app/[locale]/admin/articles/page.tsx
@@ -3,26 +3,45 @@ export const runtime = "nodejs";
 export const dynamic = "force-dynamic";
 import Link from "next/link";
 import { listArticles } from "@/data/admin/articles";
+import { Card, CardHeader, CardContent } from '@/components/ui/card'
+import Button from '@/components/ui/button'
 
 export default async function Page({ params }: { params: { locale: string } }) {
   const rows = await listArticles();
   return (
-    <div className="space-y-4">
-      <div className="flex items-center justify-between">
+    <Card>
+      <CardHeader className="flex items-center justify-between">
         <h2 className="text-xl font-medium">Articles</h2>
-        <Link className="btn" href={`/${params.locale}/admin/articles/new`}>New</Link>
-      </div>
-      <ul className="divide-y">
-        {rows.map((r: any) => (
-          <li key={r.id} className="py-3 flex items-center justify-between">
-            <div>
-              <div className="font-semibold">{r.title}</div>
-              <div className="text-xs text-gray-500">{r.slug} • {r.lang}</div>
-            </div>
-            <Link className="text-sm underline" href={`/${params.locale}/admin/articles/${r.slug}`}>Edit</Link>
-          </li>
-        ))}
-      </ul>
-    </div>
+        <Link href={`/${params.locale}/admin/articles/new`}>
+          <Button size="sm">New</Button>
+        </Link>
+      </CardHeader>
+      <CardContent className="p-0">
+        <table className="w-full text-sm">
+          <thead className="bg-muted/40 text-left">
+            <tr>
+              <th className="p-2">Title</th>
+              <th className="p-2">Slug</th>
+              <th className="p-2">Lang</th>
+              <th className="p-2"></th>
+            </tr>
+          </thead>
+          <tbody>
+            {rows.map((r: any, idx: number) => (
+              <tr key={r.id} className={idx % 2 ? 'odd:bg-muted/10' : ''}>
+                <td className="p-2 font-medium">{r.title}</td>
+                <td className="p-2 text-muted-foreground">{r.slug}</td>
+                <td className="p-2 text-muted-foreground">{r.lang}</td>
+                <td className="p-2 text-right">
+                  <Link className="underline" href={`/${params.locale}/admin/articles/${r.slug}`}>
+                    Edit
+                  </Link>
+                </td>
+              </tr>
+            ))}
+          </tbody>
+        </table>
+      </CardContent>
+    </Card>
   );
 }

--- a/src/app/[locale]/admin/email/page.tsx
+++ b/src/app/[locale]/admin/email/page.tsx
@@ -1,4 +1,5 @@
 import { supabaseServer } from '@/lib/supabaseServer'
+import { Card, CardContent } from '@/components/ui/card'
 
 export const dynamic = 'force-dynamic'
 
@@ -10,10 +11,14 @@ export default async function AdminEmail() {
       <h1 className="text-xl font-semibold">Inbox</h1>
       <ul className="space-y-2">
         {emails?.map((e: any) => (
-          <li key={e.id} className="border p-2 rounded">
-            <p className="font-medium">{e.subject}</p>
-            <p className="text-sm">{e.from} → {e.to}</p>
-            <div className="text-sm text-slate-600" dangerouslySetInnerHTML={{ __html: e.snippet || '' }} />
+          <li key={e.id}>
+            <Card>
+              <CardContent className="p-4 space-y-1">
+                <p className="font-medium">{e.subject}</p>
+                <p className="text-sm text-muted-foreground">{e.from} → {e.to}</p>
+                <div className="text-sm" dangerouslySetInnerHTML={{ __html: e.snippet || '' }} />
+              </CardContent>
+            </Card>
           </li>
         ))}
       </ul>

--- a/src/app/[locale]/admin/events/page.tsx
+++ b/src/app/[locale]/admin/events/page.tsx
@@ -3,26 +3,45 @@ export const runtime = "nodejs";
 export const dynamic = "force-dynamic";
 import Link from "next/link";
 import { listEvents } from "@/data/admin/events";
+import { Card, CardHeader, CardContent } from '@/components/ui/card'
+import Button from '@/components/ui/button'
 
 export default async function Page({ params }: { params: { locale: string } }) {
   const rows = await listEvents();
   return (
-    <div className="space-y-4">
-      <div className="flex items-center justify-between">
+    <Card>
+      <CardHeader className="flex items-center justify-between">
         <h2 className="text-xl font-medium">Events</h2>
-        <Link className="btn" href={`/${params.locale}/admin/events/new`}>New</Link>
-      </div>
-      <ul className="divide-y">
-        {rows.map((r: any) => (
-          <li key={r.id} className="py-3 flex items-center justify-between">
-            <div>
-              <div className="font-semibold">{r.title}</div>
-              <div className="text-xs text-gray-500">{r.slug} • {r.lang}</div>
-            </div>
-            <Link className="text-sm underline" href={`/${params.locale}/admin/events/${r.slug}`}>Edit</Link>
-          </li>
-        ))}
-      </ul>
-    </div>
+        <Link href={`/${params.locale}/admin/events/new`}>
+          <Button size="sm">New</Button>
+        </Link>
+      </CardHeader>
+      <CardContent className="p-0">
+        <table className="w-full text-sm">
+          <thead className="bg-muted/40 text-left">
+            <tr>
+              <th className="p-2">Title</th>
+              <th className="p-2">Slug</th>
+              <th className="p-2">Lang</th>
+              <th className="p-2"></th>
+            </tr>
+          </thead>
+          <tbody>
+            {rows.map((r: any, idx: number) => (
+              <tr key={r.id} className={idx % 2 ? 'odd:bg-muted/10' : ''}>
+                <td className="p-2 font-medium">{r.title}</td>
+                <td className="p-2 text-muted-foreground">{r.slug}</td>
+                <td className="p-2 text-muted-foreground">{r.lang}</td>
+                <td className="p-2 text-right">
+                  <Link className="underline" href={`/${params.locale}/admin/events/${r.slug}`}>
+                    Edit
+                  </Link>
+                </td>
+              </tr>
+            ))}
+          </tbody>
+        </table>
+      </CardContent>
+    </Card>
   );
 }

--- a/src/app/[locale]/admin/layout.tsx
+++ b/src/app/[locale]/admin/layout.tsx
@@ -5,8 +5,8 @@ export const dynamic = "force-dynamic";
 import { ReactNode } from "react";
 import { validateRequest } from "@/lib/auth/validateRequest";
 import { requireAdmin } from "@/lib/auth/requireAdmin";
-import Link from "next/link";
 import { redirect } from "next/navigation";
+import AdminNav from './AdminNav'
 
 export default async function AdminLayout({ children, params }: { children: ReactNode; params: { locale: string } }) {
   const { user } = await validateRequest();
@@ -18,18 +18,10 @@ export default async function AdminLayout({ children, params }: { children: Reac
 
   return (
     <section className="container mx-auto py-8">
-      <header className="flex items-center justify-between mb-6">
-        <h1 className="text-2xl font-semibold">Admin</h1>
-        <nav className="flex gap-4 text-sm">
-          <Link href={`/${params.locale}/admin/articles`}>Articles</Link>
-          <Link href={`/${params.locale}/admin/announcements`}>Announcements</Link>
-          <Link href={`/${params.locale}/admin/events`}>Events</Link>
-          <Link href={`/${params.locale}/admin/applications`}>Applications</Link>
-          <Link href={`/${params.locale}/admin/email`}>Email</Link>
-          <Link href={`/${params.locale}/admin/zoom`}>Zoom</Link>
-          <Link href={`/${params.locale}/admin/admins`}>Admins</Link>
-        </nav>
-      </header>
+      <h1 className="text-2xl font-semibold mb-6">Admin</h1>
+      <div className="sticky top-0 z-40 mb-6 border-b bg-background py-2">
+        <AdminNav locale={params.locale} />
+      </div>
       {children}
     </section>
   );

--- a/src/app/[locale]/admin/page.tsx
+++ b/src/app/[locale]/admin/page.tsx
@@ -1,6 +1,8 @@
 import { getApplicationStatusCounts } from '@/data/applications'
 import { getDoctorCount } from '@/data/doctors'
 import { getUpcomingMeetingsCount } from '@/data/zoom'
+import { Card, CardContent } from '@/components/ui/card'
+import { Users, Stethoscope, CalendarClock } from 'lucide-react'
 
 export const dynamic = 'force-dynamic'
 
@@ -11,12 +13,29 @@ export default async function AdminHome({ params: { locale } }: { params: { loca
     getUpcomingMeetingsCount()
   ])
   return (
-    <div className="container py-8 space-y-4">
-      <h1 className="text-2xl font-semibold">Admin overview</h1>
-      <div className="grid grid-cols-1 md:grid-cols-3 gap-4">
-        <div className="card"><p>Applications submitted: {counts.submitted}</p></div>
-        <div className="card"><p>Doctors: {doctorCount}</p></div>
-        <div className="card"><p>Upcoming meetings: {meetingCount}</p></div>
+    <div className="container py-8 space-y-6">
+      <div className="grid grid-cols-1 md:grid-cols-3 gap-6">
+        <Card className="flex items-center gap-4 p-4">
+          <Users className="h-8 w-8 text-primary" />
+          <CardContent className="p-0">
+            <p className="text-2xl font-bold">{counts.submitted}</p>
+            <p className="text-sm text-muted-foreground">Applications</p>
+          </CardContent>
+        </Card>
+        <Card className="flex items-center gap-4 p-4">
+          <Stethoscope className="h-8 w-8 text-primary" />
+          <CardContent className="p-0">
+            <p className="text-2xl font-bold">{doctorCount}</p>
+            <p className="text-sm text-muted-foreground">Doctors</p>
+          </CardContent>
+        </Card>
+        <Card className="flex items-center gap-4 p-4">
+          <CalendarClock className="h-8 w-8 text-primary" />
+          <CardContent className="p-0">
+            <p className="text-2xl font-bold">{meetingCount}</p>
+            <p className="text-sm text-muted-foreground">Upcoming meetings</p>
+          </CardContent>
+        </Card>
       </div>
     </div>
   )

--- a/src/app/[locale]/admin/zoom/page.tsx
+++ b/src/app/[locale]/admin/zoom/page.tsx
@@ -1,5 +1,8 @@
 import { supabaseServer } from '@/lib/supabaseServer'
 import { createMeeting } from '@/lib/zoom'
+import { Card, CardContent } from '@/components/ui/card'
+import Input from '@/components/ui/input'
+import Button from '@/components/ui/button'
 
 export const dynamic = 'force-dynamic'
 
@@ -29,15 +32,19 @@ export default async function AdminZoom() {
   return (
     <div className="container py-8 space-y-4">
       <h1 className="text-xl font-semibold">Zoom meetings</h1>
-      <ul className="list-disc pl-5">
-        {meetings?.map((m: any) => <li key={m.id}>{m.topic} – {m.starts_at}</li>)}
-      </ul>
-      <form action={add} className="flex flex-col gap-2 max-w-sm">
-        <input name="topic" placeholder="Topic" className="input" />
-        <input name="starts_at" type="datetime-local" className="input" />
-        <input name="duration" type="number" placeholder="Duration (min)" className="input" />
-        <button className="btn">Create</button>
-      </form>
+      <Card>
+        <CardContent className="p-4 space-y-4">
+          <ul className="list-disc pl-5 space-y-1">
+            {meetings?.map((m: any) => <li key={m.id}>{m.topic} – {m.starts_at}</li>)}
+          </ul>
+          <form action={add} className="flex flex-col gap-2 max-w-sm">
+            <Input name="topic" placeholder="Topic" />
+            <Input name="starts_at" type="datetime-local" />
+            <Input name="duration" type="number" placeholder="Duration (min)" />
+            <Button>Create</Button>
+          </form>
+        </CardContent>
+      </Card>
     </div>
   )
 }

--- a/src/app/[locale]/announcements/page.tsx
+++ b/src/app/[locale]/announcements/page.tsx
@@ -1,20 +1,26 @@
 import { getDictionary } from '@/lib/i18n'
 import { listAllAnnouncements } from '@/data/announcements'
+import SectionHeader from '@/components/section-header'
+import AnnouncementCard from '@/components/cards/AnnouncementCard'
+import Skeleton from '@/components/ui/skeleton'
 
 export default async function AnnouncementsPage({ params }: { params: { locale: string } }) {
   const t = await getDictionary(params.locale)
   const data = await listAllAnnouncements(params.locale)
   return (
-    <div className="container py-10">
-      <h1 className="text-3xl font-bold mb-6">{t.nav.announcements}</h1>
-      <div className="grid md:grid-cols-2 gap-4">
+    <div className="container py-10 space-y-6">
+      <SectionHeader title={t.nav.announcements} />
+      <div className="grid md:grid-cols-2 xl:grid-cols-3 gap-6">
         {data?.map((a: any) => (
-          <a key={a.id} href={`/${params.locale}/announcements/${a.slug}`} className="card hover:shadow-sm transition">
-            <div className="card-header font-semibold">{a.title}</div>
-            <div className="card-content text-sm text-slate-600 line-clamp-3">{a.summary || ''}</div>
-          </a>
+          <AnnouncementCard
+            key={a.id}
+            href={`/${params.locale}/announcements/${a.slug}`}
+            title={a.title}
+            summary={a.summary}
+          />
         ))}
-        {!data?.length && <p className="text-slate-500">{t.empty.none}</p>}
+        {data && data.length === 0 && <p className="text-muted-foreground">{t.empty.none}</p>}
+        {!data && Array.from({ length: 3 }).map((_, i) => <Skeleton key={i} className="h-24 rounded-2xl" />)}
       </div>
     </div>
   )

--- a/src/app/[locale]/articles/page.tsx
+++ b/src/app/[locale]/articles/page.tsx
@@ -1,20 +1,26 @@
 import { getDictionary } from '@/lib/i18n'
 import { listAllArticles } from '@/data/articles'
+import SectionHeader from '@/components/section-header'
+import ArticleCard from '@/components/cards/ArticleCard'
+import Skeleton from '@/components/ui/skeleton'
 
 export default async function ArticlesPage({ params }: { params: { locale: string } }) {
   const t = await getDictionary(params.locale)
   const data = await listAllArticles(params.locale)
   return (
-    <div className="container py-10">
-      <h1 className="text-3xl font-bold mb-6">{t.nav.articles}</h1>
-      <div className="grid md:grid-cols-2 gap-4">
+    <div className="container py-10 space-y-6">
+      <SectionHeader title={t.nav.articles} />
+      <div className="grid md:grid-cols-2 xl:grid-cols-3 gap-6">
         {data?.map((a: any) => (
-          <a key={a.id} href={`/${params.locale}/articles/${a.slug}`} className="card hover:shadow-sm transition">
-            <div className="card-header font-semibold">{a.title}</div>
-            <div className="card-content text-sm text-slate-600 line-clamp-3">{a.summary || ''}</div>
-          </a>
+          <ArticleCard
+            key={a.id}
+            href={`/${params.locale}/articles/${a.slug}`}
+            title={a.title}
+            summary={a.summary}
+          />
         ))}
-        {!data?.length && <p className="text-slate-500">{t.empty.none}</p>}
+        {data && data.length === 0 && <p className="text-muted-foreground">{t.empty.none}</p>}
+        {!data && Array.from({ length: 3 }).map((_, i) => <Skeleton key={i} className="h-24 rounded-2xl" />)}
       </div>
     </div>
   )

--- a/src/app/[locale]/events/page.tsx
+++ b/src/app/[locale]/events/page.tsx
@@ -1,23 +1,27 @@
 import { getDictionary } from '@/lib/i18n'
 import { listAllEvents } from '@/data/events'
+import SectionHeader from '@/components/section-header'
+import EventCard from '@/components/cards/EventCard'
+import Skeleton from '@/components/ui/skeleton'
 
 export default async function EventsPage({ params }: { params: { locale: string } }) {
   const t = await getDictionary(params.locale)
   const data = await listAllEvents(params.locale)
   return (
-    <div className="container py-10">
-      <h1 className="text-3xl font-bold mb-6">{t.nav.events}</h1>
-      <div className="grid md:grid-cols-2 gap-4">
+    <div className="container py-10 space-y-6">
+      <SectionHeader title={t.nav.events} />
+      <div className="grid md:grid-cols-2 xl:grid-cols-3 gap-6">
         {data?.map((e: any) => (
-          <a key={e.id} href={`/${params.locale}/events/${e.slug}`} className="card hover:shadow-sm transition">
-            <div className="card-header font-semibold">{e.title}</div>
-            <div className="card-content text-sm text-slate-600">
-              {e.startAt ? new Date(e.startAt).toLocaleString() : ''}
-              {e.location ? ` • ${e.location}` : ''}
-            </div>
-          </a>
+          <EventCard
+            key={e.id}
+            href={`/${params.locale}/events/${e.slug}`}
+            title={e.title}
+            date={e.startAt}
+            location={e.location}
+          />
         ))}
-        {!data?.length && <p className="text-slate-500">{t.empty.none}</p>}
+        {data && data.length === 0 && <p className="text-muted-foreground">{t.empty.none}</p>}
+        {!data && Array.from({ length: 3 }).map((_, i) => <Skeleton key={i} className="h-24 rounded-2xl" />)}
       </div>
     </div>
   )

--- a/src/app/[locale]/page.tsx
+++ b/src/app/[locale]/page.tsx
@@ -1,5 +1,9 @@
 import { getDictionary } from '@/lib/i18n'
 import Hero from '@/components/hero'
+import SectionHeader from '@/components/section-header'
+import AnnouncementCard from '@/components/cards/AnnouncementCard'
+import ArticleCard from '@/components/cards/ArticleCard'
+import EventCard from '@/components/cards/EventCard'
 import { listLatestArticles } from '@/data/articles'
 import { listLatestAnnouncements } from '@/data/announcements'
 import { listUpcomingEvents } from '@/data/events'
@@ -16,45 +20,49 @@ export default async function Home({ params }:{ params:{ locale: string } }){
     <div>
       <Hero t={t} locale={params.locale} />
 
-      <section className="container py-10">
-        <h2 className="text-xl font-bold mb-3">{t.sections.announcements}</h2>
-        <div className="grid md:grid-cols-3 gap-4">
+      <section className="container py-10 space-y-6">
+        <SectionHeader title={t.sections.announcements} />
+        <div className="grid md:grid-cols-2 xl:grid-cols-3 gap-6">
           {anns?.map((a: any) => (
-            <a key={a.id} href={`/${params.locale}/announcements/${a.slug}`} className="card hover:shadow-sm transition">
-              <div className="card-header font-semibold">{a.title}</div>
-              <div className="card-content text-sm text-slate-600 line-clamp-3">{a.summary || ''}</div>
-            </a>
+            <AnnouncementCard
+              key={a.id}
+              href={`/${params.locale}/announcements/${a.slug}`}
+              title={a.title}
+              summary={a.summary}
+            />
           ))}
-          {!anns?.length && <div className="text-slate-500">{t.empty.none}</div>}
+          {!anns?.length && <div className="text-muted-foreground">{t.empty.none}</div>}
         </div>
       </section>
 
-      <section className="container py-6">
-        <h2 className="text-xl font-bold mb-3">{t.sections.articles}</h2>
-        <div className="grid md:grid-cols-3 gap-4">
+      <section className="container py-10 space-y-6">
+        <SectionHeader title={t.sections.articles} />
+        <div className="grid md:grid-cols-2 xl:grid-cols-3 gap-6">
           {news?.map((n: any) => (
-            <a key={n.id} href={`/${params.locale}/articles/${n.slug}`} className="card hover:shadow-sm transition">
-              <div className="card-header font-semibold">{n.title}</div>
-              <div className="card-content text-sm text-slate-600 line-clamp-3">{n.summary || ''}</div>
-            </a>
+            <ArticleCard
+              key={n.id}
+              href={`/${params.locale}/articles/${n.slug}`}
+              title={n.title}
+              summary={n.summary}
+            />
           ))}
-          {!news?.length && <div className="text-slate-500">{t.empty.none}</div>}
+          {!news?.length && <div className="text-muted-foreground">{t.empty.none}</div>}
         </div>
       </section>
 
-      <section className="container py-6">
-        <h2 className="text-xl font-bold mb-3">{t.sections.events}</h2>
-        <div className="grid md:grid-cols-3 gap-4">
+      <section className="container py-10 space-y-6">
+        <SectionHeader title={t.sections.events} />
+        <div className="grid md:grid-cols-2 xl:grid-cols-3 gap-6">
           {evs?.map((e: any) => (
-            <a key={e.id} href={`/${params.locale}/events/${e.slug}`} className="card hover:shadow-sm transition">
-              <div className="card-header font-semibold">{e.title}</div>
-              <div className="card-content text-sm text-slate-600">
-                {e.startAt ? new Date(e.startAt).toLocaleString() : ''}
-                {e.location ? ` • ${e.location}` : ''}
-              </div>
-            </a>
+            <EventCard
+              key={e.id}
+              href={`/${params.locale}/events/${e.slug}`}
+              title={e.title}
+              date={e.startAt}
+              location={e.location}
+            />
           ))}
-          {!evs?.length && <div className="text-slate-500">{t.empty.none}</div>}
+          {!evs?.length && <div className="text-muted-foreground">{t.empty.none}</div>}
         </div>
       </section>
     </div>

--- a/src/components/cards/AnnouncementCard.tsx
+++ b/src/components/cards/AnnouncementCard.tsx
@@ -1,0 +1,25 @@
+import Link from 'next/link'
+import { Card, CardHeader, CardContent } from '../ui/card'
+
+export default function AnnouncementCard({
+  href,
+  title,
+  summary,
+}: {
+  href: string
+  title: string
+  summary?: string | null
+}) {
+  return (
+    <Link href={href} className="block">
+      <Card className="rounded-2xl ring-1 ring-border shadow-sm hover:shadow-md transition motion-safe:hover:-translate-y-0.5">
+        <CardHeader className="rounded-t-2xl bg-gradient-to-br from-background to-muted/40 font-semibold">
+          {title}
+        </CardHeader>
+        <CardContent className="text-sm text-muted-foreground line-clamp-3">
+          {summary}
+        </CardContent>
+      </Card>
+    </Link>
+  )
+}

--- a/src/components/cards/ArticleCard.tsx
+++ b/src/components/cards/ArticleCard.tsx
@@ -1,0 +1,25 @@
+import Link from 'next/link'
+import { Card, CardHeader, CardContent } from '../ui/card'
+
+export default function ArticleCard({
+  href,
+  title,
+  summary,
+}: {
+  href: string
+  title: string
+  summary?: string | null
+}) {
+  return (
+    <Link href={href} className="block">
+      <Card className="rounded-2xl ring-1 ring-border shadow-sm hover:shadow-md transition motion-safe:hover:-translate-y-0.5">
+        <CardHeader className="rounded-t-2xl bg-gradient-to-br from-background to-muted/40 font-semibold">
+          {title}
+        </CardHeader>
+        <CardContent className="text-sm text-muted-foreground line-clamp-3">
+          {summary}
+        </CardContent>
+      </Card>
+    </Link>
+  )
+}

--- a/src/components/cards/EventCard.tsx
+++ b/src/components/cards/EventCard.tsx
@@ -1,0 +1,39 @@
+import Link from 'next/link'
+import { Card, CardHeader, CardContent } from '../ui/card'
+import { Calendar as CalendarIcon, MapPin } from 'lucide-react'
+
+export default function EventCard({
+  href,
+  title,
+  date,
+  location,
+}: {
+  href: string
+  title: string
+  date?: string | null
+  location?: string | null
+}) {
+  return (
+    <Link href={href} className="block">
+      <Card className="rounded-2xl ring-1 ring-border shadow-sm hover:shadow-md transition motion-safe:hover:-translate-y-0.5">
+        <CardHeader className="rounded-t-2xl bg-gradient-to-br from-background to-muted/40 font-semibold">
+          {title}
+        </CardHeader>
+        <CardContent className="space-y-2 text-sm text-muted-foreground">
+          {date && (
+            <span className="inline-flex items-center gap-1 rounded-md bg-muted px-2 py-1">
+              <CalendarIcon className="h-4 w-4" />
+              {new Date(date).toLocaleString()}
+            </span>
+          )}
+          {location && (
+            <span className="inline-flex items-center gap-1 rounded-md bg-muted px-2 py-1">
+              <MapPin className="h-4 w-4" />
+              {location}
+            </span>
+          )}
+        </CardContent>
+      </Card>
+    </Link>
+  )
+}

--- a/src/components/footer.tsx
+++ b/src/components/footer.tsx
@@ -1,13 +1,15 @@
 import Link from 'next/link'
+import { Facebook, Twitter, Instagram } from 'lucide-react'
 
 export default function Footer({ t, locale }: { t: any; locale: string }) {
   return (
-    <footer className="border-t border-muted mt-10">
-      <div className="container py-10 grid md:grid-cols-3 gap-8 text-sm text-muted">
-        <div>
+    <footer className="mt-10 border-t border-muted bg-background">
+      <div className="container py-10 grid md:grid-cols-3 gap-8 text-sm text-muted-foreground">
+        <div className="space-y-2">
           <Link href={`/${locale}`} className="font-semibold text-foreground">
             {t.site.title}
           </Link>
+          <p className="max-w-xs">{t.footer.about}</p>
         </div>
         <div>
           <h3 className="font-semibold mb-2 text-foreground">{t.footer.quick}</h3>
@@ -30,13 +32,18 @@ export default function Footer({ t, locale }: { t: any; locale: string }) {
           </ul>
         </div>
         <div>
-          <h3 className="font-semibold mb-2 text-foreground">{t.footer.contact}</h3>
-          <p>
-            {t.footer.email}:{' '}
-            <a href="mailto:info@paphosma.org" className="hover:text-foreground">
-              info@paphosma.org
+          <h3 className="font-semibold mb-2 text-foreground">{t.footer.social}</h3>
+          <div className="flex gap-4 text-muted-foreground">
+            <a href="#" aria-label="Facebook" className="hover:text-foreground">
+              <Facebook className="h-5 w-5" />
             </a>
-          </p>
+            <a href="#" aria-label="Twitter" className="hover:text-foreground">
+              <Twitter className="h-5 w-5" />
+            </a>
+            <a href="#" aria-label="Instagram" className="hover:text-foreground">
+              <Instagram className="h-5 w-5" />
+            </a>
+          </div>
         </div>
       </div>
     </footer>

--- a/src/components/hero.tsx
+++ b/src/components/hero.tsx
@@ -1,17 +1,22 @@
 import Link from 'next/link'
+import Button from './ui/button'
 
 export default function Hero({ t, locale }: { t: any; locale: string }) {
   return (
-    <section className="hero">
-      <div className="container py-16">
-        <h1 className="text-4xl font-extrabold tracking-tight">{t.hero.title}</h1>
-        <p className="text-slate-600 mt-3 max-w-2xl">{t.hero.subtitle}</p>
-        <div className="mt-6 flex gap-3">
-          <Link href={`/${locale}/join`} className="btn">
-            {t.cta.join}
+    <section className="w-full bg-gradient-to-b from-primary/10 via-transparent to-transparent">
+      <div className="container py-24 text-center space-y-6">
+        <h1 className="text-5xl font-extrabold tracking-tight text-foreground">
+          {t.hero.title}
+        </h1>
+        <p className="mx-auto max-w-2xl text-lg text-muted-foreground">
+          {t.hero.subtitle}
+        </p>
+        <div className="flex justify-center gap-4 pt-4">
+          <Link href={`/${locale}/join`}>
+            <Button size="lg">{t.cta.join}</Button>
           </Link>
-          <Link href={`/${locale}/events`} className="btn-outline">
-            {t.cta.events}
+          <Link href={`/${locale}/events`}>
+            <Button variant="outline" size="lg">{t.cta.events}</Button>
           </Link>
         </div>
       </div>

--- a/src/components/navbar.tsx
+++ b/src/components/navbar.tsx
@@ -4,6 +4,15 @@ import { usePathname } from 'next/navigation'
 import { useState, useEffect } from 'react'
 import { locales } from '@/lib/i18n-config'
 import ThemeToggle from './theme-toggle'
+import {
+  Home,
+  Newspaper,
+  Megaphone,
+  Calendar,
+  UserPlus,
+  LayoutDashboard,
+  Settings,
+} from 'lucide-react'
 
 function segment(pathname: string) {
   const parts = pathname.split('/').filter(Boolean)
@@ -27,38 +36,49 @@ export default function Navbar({ t, locale }: { t: any; locale: string }) {
       .catch(err => console.error('Failed to fetch session:', err))
   }, [])
 
-  const nav = [
-    { href: `/${locale}`, label: t.nav.home, key: '' },
-    { href: `/${locale}/articles`, label: t.nav.articles, key: 'articles' },
-    { href: `/${locale}/announcements`, label: t.nav.announcements, key: 'announcements' },
-    { href: `/${locale}/events`, label: t.nav.events, key: 'events' },
-    { href: `/${locale}/join`, label: t.nav.join, key: 'join' },
+  let nav = [
+    { href: `/${locale}`, label: t.nav.home, key: '', icon: Home },
+    { href: `/${locale}/articles`, label: t.nav.articles, key: 'articles', icon: Newspaper },
+    { href: `/${locale}/announcements`, label: t.nav.announcements, key: 'announcements', icon: Megaphone },
+    { href: `/${locale}/events`, label: t.nav.events, key: 'events', icon: Calendar },
+    { href: `/${locale}/join`, label: t.nav.join, key: 'join', icon: UserPlus },
   ]
-  if (role === 'doctor') nav.push({ href: `/${locale}/dashboard`, label: t.nav.dashboard, key: 'dashboard' })
-  if (role === 'admin' || role === 'super_admin') nav.push({ href: `/${locale}/admin`, label: t.nav.admin, key: 'admin' })
+  if (role === 'doctor') nav.push({ href: `/${locale}/dashboard`, label: t.nav.dashboard, key: 'dashboard', icon: LayoutDashboard })
+  if (role === 'admin' || role === 'super_admin') nav.push({ href: `/${locale}/admin`, label: t.nav.admin, key: 'admin', icon: Settings })
   return (
-    <nav className="navbar sticky top-0 z-40 sticky-blur">
+    <nav className="sticky top-0 z-50 border-b supports-[backdrop-filter]:bg-white/70 supports-[backdrop-filter]:backdrop-blur dark:supports-[backdrop-filter]:bg-black/30">
       <div className="container flex items-center justify-between h-16">
-        <Link href={`/${locale}`} className="font-semibold text-slate-800">
+        <Link href={`/${locale}`} className="font-semibold text-foreground">
           {t.site.title}
         </Link>
-        <button className="md:hidden" onClick={() => setOpen(v => !v)}>☰</button>
+        <button
+          className="md:hidden h-8 w-8 flex items-center justify-center rounded-md focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-primary"
+          aria-label="Toggle menu"
+          onClick={() => setOpen(v => !v)}
+        >
+          ☰
+        </button>
         <div className="hidden md:flex items-center gap-4">
-          {nav.map(n => (
-            <Link
-              key={n.href}
-              href={n.href}
-              className={`text-sm ${current === n.key ? 'text-primary' : 'text-slate-600 hover:text-slate-900'}`}
-            >
-              {n.label}
-            </Link>
-          ))}
-          <Link href={`/${locale}/login`} className="text-sm text-slate-600 hover:text-slate-900">
+          {nav.map(n => {
+            const Icon = n.icon
+            const active = current === n.key
+            return (
+              <Link
+                key={n.href}
+                href={n.href}
+                className={`flex items-center gap-1 text-sm px-2 py-1 rounded-md transition-colors ${active ? 'text-primary underline underline-offset-4' : 'text-muted-foreground hover:text-foreground'}`}
+              >
+                <Icon className="h-4 w-4" />
+                {n.label}
+              </Link>
+            )
+          })}
+          <Link href={`/${locale}/login`} className="text-sm text-muted-foreground hover:text-foreground">
             {t.nav.login}
           </Link>
           <ThemeToggle />
           <select
-            className="text-sm border rounded-xl px-2 py-1"
+            className="text-sm border rounded-xl px-2 py-1 bg-background"
             defaultValue={locale}
             onChange={(e) => {
               const next = e.target.value
@@ -76,26 +96,31 @@ export default function Navbar({ t, locale }: { t: any; locale: string }) {
         </div>
       </div>
       {open && (
-        <div className="md:hidden border-t border-slate-200 px-4 py-2 flex flex-col gap-2">
-          {nav.map(n => (
-            <Link
-              key={n.href}
-              href={n.href}
-              className={`text-sm ${current === n.key ? 'text-primary' : 'text-slate-600 hover:text-slate-900'}`}
-              onClick={() => setOpen(false)}
-            >
-              {n.label}
-            </Link>
-          ))}
+        <div className="md:hidden border-t border-border bg-background px-4 py-2 flex flex-col gap-2">
+          {nav.map(n => {
+            const Icon = n.icon
+            const active = current === n.key
+            return (
+              <Link
+                key={n.href}
+                href={n.href}
+                className={`flex items-center gap-2 text-sm p-2 rounded-md ${active ? 'bg-muted text-primary' : 'text-muted-foreground hover:text-foreground'}`}
+                onClick={() => setOpen(false)}
+              >
+                <Icon className="h-4 w-4" />
+                {n.label}
+              </Link>
+            )
+          })}
           <Link
             href={`/${locale}/login`}
-            className="text-sm text-slate-600 hover:text-slate-900"
+            className="text-sm text-muted-foreground hover:text-foreground"
             onClick={() => setOpen(false)}
           >
             {t.nav.login}
           </Link>
           <select
-            className="text-sm border rounded-xl px-2 py-1 mt-2"
+            className="text-sm border rounded-xl px-2 py-1 mt-2 bg-background"
             value={locale}
             onChange={(e) => {
               const next = e.target.value

--- a/src/components/section-header.tsx
+++ b/src/components/section-header.tsx
@@ -1,0 +1,21 @@
+import clsx from 'clsx'
+
+export default function SectionHeader({
+  eyebrow,
+  title,
+  description,
+  className = '',
+}: {
+  eyebrow?: string
+  title: string
+  description?: string
+  className?: string
+}) {
+  return (
+    <div className={clsx('space-y-1 text-center', className)}>
+      {eyebrow && <p className="text-xs font-medium text-primary uppercase tracking-wide">{eyebrow}</p>}
+      <h2 className="text-2xl font-bold text-foreground">{title}</h2>
+      {description && <p className="text-sm text-muted-foreground max-w-2xl mx-auto">{description}</p>}
+    </div>
+  )
+}


### PR DESCRIPTION
## Summary
- implement glassy sticky navbar with icons, mobile drawer, and active tab styling
- refresh homepage with gradient hero, section headers, and hover-lift content cards
- overhaul admin dashboard with KPI cards and consistent card/table UI

## Testing
- `pnpm typecheck`
- `pnpm lint`
- `CI=1 pnpm build`
- `pnpm smoke`


------
https://chatgpt.com/codex/tasks/task_e_689d008740d0832bbd0b35d1e78bdd2f